### PR TITLE
Belgian experiments parsed and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/collab-react-components-mongo/
 /.ipynb_checkpoints/
 /.idea/
 /etherpad/
 /stian logs/
 /etherpad-lite-win-1.6.2-32027134cb.zip
-/belgian experiment/
+/belgian_experiment/
+/analytics/figures/
+/analytics/texts/

--- a/analytics/Pad.py
+++ b/analytics/Pad.py
@@ -205,7 +205,7 @@ class Pad:
             print(op)
             print()
 
-    def create_paragraphs_from_ops(self,new_elem_ops_sorted):
+    def create_paragraphs_from_ops(self, new_elem_ops_sorted):
         """
         Build the paragraphs for the pad based on the existing paragraphs and the new elementary operations
 
@@ -220,15 +220,15 @@ class Pad:
             for para_i, paragraph in enumerate(self.paragraphs):
                 if (not paragraph.new_line) \
                         and paragraph.abs_position \
-                                <= elem_op_to_look_for.abs_position \
-                                <= paragraph.abs_position + paragraph.get_length():
+                        <= elem_op_to_look_for.abs_position \
+                        <= paragraph.abs_position + paragraph.get_length():
                     return para_i
             return -1
 
         # We will look at each elem_op and assign it to a new/existing paragraph
         for elem_op in new_elem_ops_sorted:
             # From where we will change the paragraph indices
-            # should be infity but this is enough since we can't add more than 2 paragraph
+            # should be infinity but this is enough since we can't add more than 2 paragraph
             update_indices_from = len(self.paragraphs) + 3
 
             # If it is a new line, we will create a new paragraph and insert it at the right place
@@ -311,7 +311,7 @@ class Pad:
                     # We are deleting only this paragraph
                     if elem_op.abs_position == para.abs_position \
                             and elem_op.abs_position + elem_op.length_to_delete \
-                                    == para.abs_position + para.get_length():
+                            == para.abs_position + para.get_length():
                         # Add to the list to remove
                         to_remove.append(para_idx)
                         # We will update the indices from here
@@ -340,7 +340,7 @@ class Pad:
                     elif elem_op.abs_position \
                             <= para.abs_position \
                             and elem_op.abs_position + elem_op.length_to_delete \
-                                    >= para.abs_position + para.get_length():
+                            >= para.abs_position + para.get_length():
                         # We remove the whole paragraph
                         to_remove.append(para_idx)
                         # shouldn't be necessary since it will be taken care by the last paragraph we delete.
@@ -467,8 +467,8 @@ class Pad:
             assert self.paragraphs == sorted(self.paragraphs)
             # checking that length is not 0
             for i in range(0, len(self.paragraphs)):
-                if self.paragraphs[i].length==0:
-                    print(self.pad_name,i,"\n",elem_op)
+                if self.paragraphs[i].length == 0:
+                    print(self.pad_name, i, "\n", elem_op)
                     raise AssertionError
             # Checking that the paragraphs touch each others
             for i in range(1, len(self.paragraphs)):
@@ -521,11 +521,13 @@ class Pad:
 
     def build_operation_context(self, delay_sync, time_to_reset_day, time_to_reset_break):
         """
-        Build the context of each operation progressively added to the pad. The context is a dictionary containing whether a
-         pad is synchronous wih an other author in the pad or in the paragraph and it contains list of authors accordingly.
+        Build the context of each operation progressively added to the pad. The context is a dictionary containing
+        whether a pad is synchronous wih an other author in the pad or in the paragraph and it contains list of
+        authors accordingly.
 
         :param delay_sync: delay of synchronization between two authors
-        :param time_to_reset_day: Number of milliseconds between two ops to indicate the first op of the day, by default 8h
+        :param time_to_reset_day: Number of milliseconds between two ops to indicate the first op of the day, by default
+                8h
         :param time_to_reset_break: Number of milliseconds to indicate the first op after a break, by default 10min
         :return: None
         """
@@ -562,7 +564,8 @@ class Pad:
                         op.context['first_op_break'] = True
                 op_index += 1
 
-                if other_op.author != op.author and end_time + delay_sync >= other_start_time >= start_time - delay_sync:
+                if other_op.author != op.author\
+                        and end_time + delay_sync >= other_start_time >= start_time - delay_sync:
                     op.context['synchronous_in_pad'] = True
                     op.context['synchronous_in_pad_with'].append(other_op.author)
         for para in self.paragraphs:
@@ -579,7 +582,8 @@ class Pad:
 
                 for other_op in para_ops:
                     other_start_time = other_op.timestamp_start
-                    if other_op.author != op.author and end_time + delay_sync >= other_start_time >= start_time - delay_sync:
+                    if other_op.author != op.author \
+                            and end_time + delay_sync >= other_start_time >= start_time - delay_sync:
                         op.context['synchronous_in_paragraph'] = True
                         op.context['synchronous_in_paragraph_with'].append(other_op.author)
 
@@ -587,8 +591,6 @@ class Pad:
             # Once we computed the absolute length of the paragraph, we compute the proportion (it is positive)
             for op in para_ops:
                 op.context['proportion_paragraph'] /= abs_length_para
-
-
 
     def author_proportions(self, considerate_admin=True):
         """
@@ -620,7 +622,8 @@ class Pad:
         proportions = author_lengths / overall_length
         return authors, proportions
 
-    def compute_entropy_prop(self, proportions, len_authors):
+    @staticmethod
+    def compute_entropy_prop(proportions, len_authors):
         """
         Compute the proportion score using the entropy and proportions.
         :param proportions: list of proportions summing up to 1
@@ -651,7 +654,7 @@ class Pad:
         Compute the synchronous and asynchronous scores.
 
         :return: synchronous and asynchronous scores, floats between 0 and 1.
-        :rtype: float
+        :rtype: (float,float)
         """
         prop_sync = 0
         prop_async = 0
@@ -684,7 +687,7 @@ class Pad:
                 i += 1
                 for op in paragraph.operations:
                     prop_authors[op.author] += abs(op.context[
-                        'proportion_paragraph'])  # increment with the corresponding prop
+                                                       'proportion_paragraph'])  # increment with the corresponding prop
                 prop_authors_paragraphs.append(prop_authors)
         return paragraph_names, prop_authors_paragraphs
 

--- a/analytics/main.py
+++ b/analytics/main.py
@@ -8,21 +8,20 @@ import config
 # list_of_elem_ops_per_pad = get_elem_ops_per_pad_from_ether_csv(path_to_csv)
 path_to_db = "..\\etherpad\\var\\dirty.db"
 
-list_of_elem_ops_per_pad,_ = get_elem_ops_per_pad_from_db(path_to_db=path_to_db, editor='etherpad')
-#list_of_elem_ops_per_pad,_ = get_elem_ops_per_pad_from_db(editor='collab-react-components')
+list_of_elem_ops_per_pad, _ = get_elem_ops_per_pad_from_db(path_to_db=path_to_db, editor='etherpad')
+# list_of_elem_ops_per_pad,_ = get_elem_ops_per_pad_from_db(editor='collab-react-components')
 
-pads,_,elem_ops_treated = operation_builder.build_operations_from_elem_ops(list_of_elem_ops_per_pad,
-                                                        config.maximum_time_between_elem_ops)
+pads, _, elem_ops_treated = operation_builder.build_operations_from_elem_ops(list_of_elem_ops_per_pad,
+                                                                             config.maximum_time_between_elem_ops)
 
 for pad_name in pads:
-    pad=pads[pad_name]
+    pad = pads[pad_name]
     # create the paragraphs
     pad.create_paragraphs_from_ops(elem_ops_treated[pad_name])
     # classify the operations of the pad
-    pad.classify_operations(length_edit=config.length_edit,length_delete=config.length_delete)
+    pad.classify_operations(length_edit=config.length_edit, length_delete=config.length_delete)
     # find the context of the operation of the pad
-    pad.build_operation_context(config.delay_sync, config.time_to_reset_day,config.time_to_reset_break)
-
+    pad.build_operation_context(config.delay_sync, config.time_to_reset_day, config.time_to_reset_break)
 
 for pad_name in pads:
     pad = pads[pad_name]
@@ -40,26 +39,26 @@ for pad_name in pads:
     print('User proportion per paragraph score', pad.user_participation_paragraph_score())
     print('Proportion score:', pad.prop_score())
     print('Synchronous score:', pad.sync_score()[0])
-    print('Alternating score:',pad.alternating_score())
+    print('Alternating score:', pad.alternating_score())
     print('Break score day:', pad.break_score('day'))
     print('Break score short:', pad.break_score('short'))
 
-    display_user_participation(pad)
+    display_user_participation(pad, config.figs_save_location)
     # plot the participation proportion per user per paragraphs
-    display_user_participation_paragraphs(pad)
-    display_user_participation_paragraphs_with_del(pad)
+    display_user_participation_paragraphs(pad, config.figs_save_location)
+    display_user_participation_paragraphs_with_del(pad, config.figs_save_location)
 
     # plot the proportion of synchronous writing per paragraphs
-    display_proportion_sync_in_paragraphs(pad)
+    display_proportion_sync_in_paragraphs(pad, config.figs_save_location)
 
     # plot the overall type counts
-    display_overall_op_type(pad)
+    display_overall_op_type(pad, config.figs_save_location)
 
     # plot the counts of type per users
-    display_types_per_user(pad)
+    display_types_per_user(pad, config.figs_save_location)
 
     # print('OPERATIONS')
-    pad.display_operations()
+    #   pad.display_operations()
 
     # print("PARAGRAPHS:")
-    pad.display_paragraphs(verbose=1)
+    #   pad.display_paragraphs(verbose=1)

--- a/analytics/main_belgians.py
+++ b/analytics/main_belgians.py
@@ -1,0 +1,70 @@
+import config
+import operation_builder
+from analytics.parser import *
+from analytics.visualization import *
+import os
+
+list_of_elem_ops_per_pad = dict()
+elemOpsCounter = 0
+root_of_dbs = "../belgian_experiment/"
+for (dirpath, dirnames, filenames) in os.walk(root_of_dbs):
+    for filename in filenames:
+        if ".db" in filename:
+            path_to_db = os.path.join(dirpath, filename)
+            list_of_elem_ops_per_main, _ = get_elem_ops_per_pad_from_db(path_to_db=path_to_db, editor='etherpadSQLite3')
+            pad_name = path_to_db[len(root_of_dbs):path_to_db.find("data") - 1]
+            assert len(list_of_elem_ops_per_main.keys()) == 1
+            list_of_elem_ops_per_pad[pad_name] = list_of_elem_ops_per_main['main']
+
+pads, _, elem_ops_treated = operation_builder.build_operations_from_elem_ops(list_of_elem_ops_per_pad,
+                                                                             config.maximum_time_between_elem_ops)
+
+for pad_name in pads:
+    elemOpsCounter += len(elem_ops_treated[pad_name])
+    pad = pads[pad_name]
+    # create the paragraphs
+    pad.create_paragraphs_from_ops(elem_ops_treated[pad_name])
+    # classify the operations of the pad
+    pad.classify_operations(length_edit=config.length_edit, length_delete=config.length_delete)
+    # find the context of the operation of the pad
+    pad.build_operation_context(config.delay_sync, config.time_to_reset_day, config.time_to_reset_break)
+
+print("There are %s pads with a total of %s elementary operations" % (str(len(pads)), str(elemOpsCounter)))
+
+for pad_name in pads:
+    pad = pads[pad_name]
+    to_print = "PAD:" + pad_name + "\n" \
+               + "TEXT:\n" + pad.get_text() + "\n" \
+               + '\nCOLORED TEXT BY AUTHOR\n' + pad.display_text_colored_by_authors() + "\n" \
+               + '\nCOLORED TEXT BY OPS\n' + pad.display_text_colored_by_ops() + "\n" \
+               + '\nSCORES' \
+               + '\nUser proportion per paragraph score:' + str(pad.user_participation_paragraph_score()) \
+               + '\nProportion score:' + str(pad.prop_score()) \
+               + '\nSynchronous score:' + str(pad.sync_score()[0]) \
+               + '\nAlternating score:' + str(pad.alternating_score()) \
+               + '\nBreak score day:' + str(pad.break_score('day')) \
+               + '\nBreak score short:' + str(pad.break_score('short'))
+    print(to_print)
+    with open("texts/"+pad_name+".txt","w+",encoding='utf-8') as f:
+        f.write(to_print)
+
+
+    display_user_participation(pad, config.figs_save_location)
+    # plot the participation proportion per user per paragraphs
+    display_user_participation_paragraphs(pad, config.figs_save_location)
+    display_user_participation_paragraphs_with_del(pad, config.figs_save_location)
+
+    # plot the proportion of synchronous writing per paragraphs
+    display_proportion_sync_in_paragraphs(pad, config.figs_save_location)
+
+    # plot the overall type counts
+    display_overall_op_type(pad, config.figs_save_location)
+
+    # plot the counts of type per users
+    display_types_per_user(pad, config.figs_save_location)
+
+    # print('OPERATIONS')
+    #   pad.display_operations()
+
+    # print("PARAGRAPHS:")
+    #   pad.display_paragraphs(verbose=1)

--- a/analytics/visualization.py
+++ b/analytics/visualization.py
@@ -5,10 +5,11 @@ import seaborn as sns
 import os
 
 
-def display_user_participation(pad):
+def display_user_participation(pad, save_location):
     """
     Display a pie chart representing the participation according to the length of each authors
 
+    :param save_location: Where to store the figure
     :param pad:
     :return: None
     """
@@ -22,70 +23,75 @@ def display_user_participation(pad):
     df.index = df['Authors']
 
     # Plot the results as a pie chart
-    plt.figure()
+    plt.figure(figsize=(16, 16))
     df.plot.pie(y='Participation proportion', autopct='%1.0f%%')
     plt.title('Proportion of participation by authors')
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_user_participation' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_user_participation.png' % (pad.pad_name, pad.pad_name),bbox_inches='tight')
 
 
-def display_overall_op_type(pad):
+def display_overall_op_type(pad, save_location, jump=False):
     """
     Plot the type counts of all operations of the pad.
 
+    :param save_location:
     :param pad:
     :return: None
     """
     # Initialize the bins and fill them
-    types = ['write', 'edit', 'delete', 'paste', 'jump']
+    types = ['write', 'edit', 'delete', 'paste']
     type_counts = np.zeros(len(types))
     for op in pad.operations:
-        type_counts[types.index(op.type)] += 1
+        if jump or op.type != 'jump':
+            type_counts[types.index(op.type)] += 1
 
-    # Transform the array in dataframe
+    # Transform the array in DataFrame
     df = pd.DataFrame({'Type Counts': type_counts,
                        'Types': types
                        })
     df.index = df['Types']
 
-    # Plot the results as a seaborn barplot
-    plt.figure()
+    # Plot the results as a Seaborn barplot
+    plt.figure(figsize=(16, 16))
     sns.barplot(x='Types', y='Type Counts', data=df)
     plt.title('Type repartition of operations of the pad')
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_overall_op_type' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_overall_op_type.png' % (pad.pad_name, pad.pad_name),bbox_inches='tight')
 
 
-def display_types_per_user(pad):
+def display_types_per_user(pad, save_location, jump=False):
     """
     Plot the type counts of all operations of the pad for all users separately.
 
+    :param jump:
+    :param save_location:
     :param pad:
     :return: None
     """
-    # Initialize the bins and fill them
-    types = ['write', 'edit', 'delete', 'paste', 'jump']
 
-    # Create dataframe and fill it
+    # Create DataFrame and fill it
     df = pd.DataFrame(columns=('Operations', 'Types', 'Authors'))
     for i, op in enumerate(pad.operations):
         df.loc[i] = [op, op.type, op.author]
+    if not jump:
+        df = df[df['Types'] != 'jump']
 
     # Plot the results as a seaborn countplot
-    plt.figure()
+    plt.figure(figsize=(16, 16))
     sns.countplot(x='Types', hue="Authors", data=df)
     plt.title('Type repartition of operations of the pad per user')
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_types_per_user' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_types_per_user.png' % (pad.pad_name, pad.pad_name),bbox_inches='tight')
 
 
-def display_proportion_sync_in_pad(pad):
+def display_proportion_sync_in_pad(pad, save_location):
     """
     Display in a pie chart the proportion of synchronous writing in the entire pad
 
+    :param save_location:
     :param pad:
     :return: None
     """
@@ -94,18 +100,19 @@ def display_proportion_sync_in_pad(pad):
     df = pd.DataFrame({'sync/async proportion': [prop_sync, prop_async]}, index=['synchronous', 'asynchronous'])
 
     # Plot the results as a pie chart
-    plt.figure()
+    plt.figure(figsize=(16, 16))
     df.plot.pie(y='sync/async proportion', autopct='%1.0f%%', color=['yellow', 'grey'])
     plt.title('Proportion of {a}synchronous writing in the pad')
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_sync_prop_pad' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_sync_prop_pad.png' % (pad.pad_name, pad.pad_name),bbox_inches='tight')
 
 
-def display_proportion_sync_in_paragraphs(pad):
+def display_proportion_sync_in_paragraphs(pad, save_location):
     """
     Display in a barplot the proportion of synchronous writing in all the paragraphs (not the jump lines)
 
+    :param save_location:
     :param pad:
     :return: None
     """
@@ -130,20 +137,21 @@ def display_proportion_sync_in_paragraphs(pad):
                       index=paragraph_names)
 
     # Plot the results as a pie chart
-    plt.figure()
+    plt.figure(figsize=(16, 16))
     df.plot.barh(y=['sync proportion', 'async proportion'], stacked=True, color=['yellow', 'grey'])
     plt.gca().invert_yaxis()
     plt.title('Proportion of {a}synchronous writing in paragraphs')
     plt.legend(loc='upper center', bbox_to_anchor=(0.5, -0.05), ncol=2)
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_sync_prop_para' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_sync_prop_para.png' % (pad.pad_name, pad.pad_name),bbox_inches='tight')
 
 
-def display_user_participation_paragraphs(pad):
+def display_user_participation_paragraphs(pad, save_location):
     """
     Display in a barplot the proportion of author writing in all the paragraphs (not the jump lines)
 
+    :param save_location:
     :param pad:
     :return: None
     """
@@ -156,21 +164,22 @@ def display_user_participation_paragraphs(pad):
                       index=paragraph_names)
 
     # Plot the results as a stacked plot bar
-    plt.figure()
+    plt.figure(figsize=(16, 16))
     df.plot.barh(y=author_names, stacked=True)
     plt.gca().invert_yaxis()
     plt.title('Proportion of absolute writings (overall additions) per authors in paragraphs')
     plt.legend(loc='upper center', bbox_to_anchor=(0.5, -0.05), ncol=len(author_names))
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_user_abs_participation_para' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_user_abs_participation_para.png' % (pad.pad_name, pad.pad_name),bbox_inches='tight')
 
 
-def display_user_participation_paragraphs_with_del(pad):
+def display_user_participation_paragraphs_with_del(pad, save_location):
     """
     Display in a barplot the proportion of author writing in all the paragraphs (not the jump lines) with the del
     operations
 
+    :param save_location:
     :param pad:
     :return: None
     """
@@ -201,7 +210,7 @@ def display_user_participation_paragraphs_with_del(pad):
             prop_authors_paragraphs_add.append(prop_authors_add)
             prop_authors_paragraphs_del.append(prop_authors_del)
 
-    # Transform the final data into a pandas dataframe
+    # Transform the final data into a pandas DataFrame
     df_add = pd.DataFrame(prop_authors_paragraphs_add, index=paragraph_names)
     df_add.columns += ' write/add'
     df_del = pd.DataFrame(prop_authors_paragraphs_del, index=paragraph_names)
@@ -210,11 +219,11 @@ def display_user_participation_paragraphs_with_del(pad):
     df = df.sort_index(axis=1)
 
     # Plot the results as a stacked plot bar
-    plt.figure()
+    plt.figure(figsize=(16, 16))
     df.plot.barh(y=df.columns, stacked=True, color=sns.color_palette("Paired", 40))
     plt.gca().invert_yaxis()
     plt.title('Proportion of writings per authors in paragraphs with deletions and additions seperated')
     plt.legend(loc='upper center', bbox_to_anchor=(0.5, -0.05), ncol=len(author_names))
-    if not os.path.isdir('../figures/'+pad.pad_name):
-        os.makedirs('../figures/'+pad.pad_name)
-    plt.savefig('../figures/%s/%s_user_participation_para' % (pad.pad_name, pad.pad_name))
+    if not os.path.isdir(save_location + '/' + pad.pad_name):
+        os.makedirs(save_location + '/' + pad.pad_name)
+    plt.savefig(save_location + '/%s/%s_user_participation_para.png' % (pad.pad_name, pad.pad_name), bbox_inches='tight')

--- a/config.py
+++ b/config.py
@@ -6,3 +6,4 @@ time_to_reset_day = int(288e5)  # time to reinitialize the first op of the day (
 time_to_reset_break = 600000  # time to reset first op after a break (10min)
 length_edit = 10  # Threshold in length to differentiate a Write type from an Edit or an edit from a Deletion.
 length_delete = 10  # Threshold in length to consider the op as a deletion
+figs_save_location = './figures'


### PR DESCRIPTION
Belgian experimented parsed with sqlite3. Modularized the etherpad parsers. Added assertions in the parsing to check that they indeed are ordered. It will also save the text and score to a text file to study them. Added location for saving the visualizations. The vizualization saving trimmed the file, fixes #13 . Displaying the overall type repartition and types of operations per user no longer display jumps. gitignore ignores the belgian experiments and their figures and texts. Config has been modified to store the figs in ./figures. Warning from pandas comes from vizualization lines 217 and 215 #8.